### PR TITLE
Allow for more configurable build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,13 @@ ROOT=$(shell pwd)
 CURSES=
 CURSES_PREFIX=$(HOME)
 ifeq ($(CROSS),)
-  BUILD=$(ROOT)/../build
+  BUILD?=$(ROOT)/../build
+  PREFIX?=/opt/parallax
   CFGCROSS=
   CROSSCC=gcc
 else
-  BUILD=$(ROOT)/../build-$(CROSS)
-  PREFIX=/opt/parallax-$(CROSS)
+  BUILD?=$(ROOT)/../build-$(CROSS)
+  PREFIX?=/opt/parallax-$(CROSS)
   ifeq ($(CROSS),win32)
     CROSS_TARGET=i586-mingw32msvc
     CFGCROSS=--host=$(CROSS_TARGET)
@@ -44,8 +45,6 @@ else
     endif
   endif
 endif
-
-PREFIX?=/opt/parallax
 
 ECHO=echo
 RM=rm

--- a/demos/common/common.mk
+++ b/demos/common/common.mk
@@ -19,15 +19,11 @@
 # #########################################################
 
 # where we installed the propeller binaries and libraries
-PREFIX = /opt/parallax
+PREFIX ?= /opt/parallax
 
-ifndef MODEL
-MODEL=lmm
-endif
+MODEL?=lmm
 
-ifndef BOARD
-BOARD=$(PROPELLER_LOAD_BOARD)
-endif
+BOARD?=$(PROPELLER_LOAD_BOARD)
 
 ifneq ($(BOARD),)
 BOARDFLAG=-b$(BOARD)

--- a/demos/common/demo.mk
+++ b/demos/common/demo.mk
@@ -19,7 +19,7 @@
 # #########################################################
 
 # where we installed the propeller binaries and libraries
-PREFIX = /opt/parallax
+PREFIX ?= /opt/parallax
 
 # libgcc directory
 LIBGCC = $(PREFIX)/lib/gcc/propeller-elf/4.6.1

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -2,9 +2,7 @@
 # Makefile for Propeller C library
 #
 
-ifndef PREFIX
-PREFIX = /opt/parallax
-endif
+PREFIX ?= /opt/parallax
 
 DEST = $(PREFIX)/propeller-elf
 

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -29,17 +29,17 @@ then
   cd ..
   exit 1
 fi
-mkdir -p /opt/parallax/share/lib
+mkdir -p $PREFIX/share/lib
 if test $? != 0
 then
-  echo "mkdir /opt/parallax/share/lib failed"
+  echo "mkdir $PREFIX/share/lib failed"
   cd ..
   exit 1
 fi
-cp -r html /opt/parallax/share/lib
+cp -r html $PREFIX/share/lib
 if test $? != 0
 then
-  echo "cp -r html /opt/parallax/share/lib failed"
+  echo "cp -r html $PREFIX/share/lib failed"
   cd ..
   exit 1
 fi

--- a/loader/Makefile
+++ b/loader/Makefile
@@ -2,13 +2,9 @@
 # propeller-load Makefile #
 ###########################
 
-ifndef BUILDROOT
-BUILDROOT=.
-endif
+BUILDROOT?=.
 
-ifndef TARGET
-TARGET=/opt/parallax
-endif
+TARGET?=/opt/parallax
 
 SRCDIR=src
 SPINDIR=spin

--- a/loader/build.sh
+++ b/loader/build.sh
@@ -6,7 +6,9 @@
 #
 # ADJUST THE FOLLOWING VARIABLES IF NECESSARY
 #
-PREFIX=/opt/parallax
+if [ -z "$PREFIX" ] ; then
+  PREFIX=/opt/parallax
+fi
 export PREFIX
 
 #

--- a/spin2cpp/Makefile
+++ b/spin2cpp/Makefile
@@ -3,13 +3,9 @@
 # Copyright (c) 2011 Total Spectrum Software Inc.
 #
 
-ifndef BUILDROOT
-BUILDROOT=.
-endif
+BUILDROOT?=.
 
-ifndef TARGET
-TARGET=/opt/parallax
-endif
+TARGET?=/opt/parallax
 
 ifeq ($(OS),linux)
 EXT=


### PR DESCRIPTION
These changes should allow for easier builds on a continuous integration server, where the binaries should not be installed to /opt/parallax and the build directory needs to (should) be underneath the root instead of next to the root.